### PR TITLE
Reposition mobile Castle Clashers HUD timer

### DIFF
--- a/castle-clashers.css
+++ b/castle-clashers.css
@@ -201,12 +201,12 @@ button { touch-action: manipulation; }
     margin-top: 4px;
   }
   #hud {
-    left: auto;
-    right: calc(clamp(8px, 3vw, 24px) + 56px);
+    left: clamp(8px, 3vw, 24px);
+    right: auto;
     top: 50%;
     transform: translateY(-50%);
-    align-items: center;
-    gap: 0;
+    align-items: flex-start;
+    gap: 4px;
   }
   .floating-menu {
     top: 50%;


### PR DESCRIPTION
## Summary
- reposition the Castle Clashers HUD timer to anchor on the left edge for small screens
- adjust mobile alignment spacing so the timer remains readable without overlapping the hamburger menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690935fa7aa08323896d50d93cbaef18