### PR TITLE
Add responsive menu, audio, and tuna bomb polish to Catiero

### DIFF
--- a/catiero.css
+++ b/catiero.css
@@ -22,6 +22,7 @@ body {
   background: var(--bg);
   color: var(--fg);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  overflow: hidden;
 }
 
 .wrap {
@@ -30,6 +31,13 @@ body {
   padding: 12px 12px 24px;
   display: grid;
   gap: 12px;
+  min-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  .wrap {
+    min-height: 100dvh;
+  }
 }
 
 h1 {
@@ -38,7 +46,7 @@ h1 {
   letter-spacing: 0.5px;
 }
 
-.hud {
+header.hud {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -50,13 +58,80 @@ h1 {
   image-rendering: pixelated; /* pixel vibe */
 }
 
-.score {
+.hud-menu-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid #2b323a;
+  background: #11161b;
+  color: var(--fg);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.12s ease;
+}
+
+.hud-menu-btn:hover {
+  background: #1c232b;
+}
+
+.hud-menu-btn:active {
+  transform: translateY(1px);
+}
+
+.hud-menu-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.hud-menu-btn__icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.hud-menu-btn__label {
+  letter-spacing: 0.5px;
+}
+
+.scoreboard {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+}
+
+.scoreboard__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 82px;
+  background: rgba(17, 22, 27, 0.75);
+  border: 1px solid #2b323a;
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+
+.scoreboard__label {
+  font-size: 11px;
+  letter-spacing: 0.6px;
+  opacity: 0.8;
+  text-transform: uppercase;
+}
+
+.scoreboard__score {
+  font-size: 20px;
   font-weight: 700;
 }
 
-.legend {
-  opacity: 0.9;
-  font-size: 12px;
+.scoreboard__item--p1 .scoreboard__score {
+  color: var(--p1);
+}
+
+.scoreboard__item--p2 .scoreboard__score {
+  color: var(--p2);
 }
 
 canvas {
@@ -66,33 +141,6 @@ canvas {
   border-radius: 10px;
   background: #0b0e10;
   image-rendering: pixelated;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: #11161b;
-  border: 1px solid #2b323a;
-  font-size: 12px;
-}
-
-.p1dot,
-.p2dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.p1dot {
-  background: var(--p1);
-}
-
-.p2dot {
-  background: var(--p2);
 }
 
 .weapon-bar {
@@ -141,6 +189,12 @@ canvas {
 
 .weapon-btn:hover {
   background: #202830;
+}
+
+.weapon-btn[disabled] {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .weapon-btn.active {
@@ -310,7 +364,23 @@ body.is-touch .touch-controls {
 }
 
 body.is-touch .weapon-bar {
-  margin-bottom: 76px;
+  display: none;
+}
+
+body.is-touch .wrap {
+  padding-bottom: 120px;
+}
+
+body.ai-opponent .weapon-panel--p2 {
+  display: none;
+}
+
+body.ai-opponent .touch-group--right {
+  display: none;
+}
+
+body.ai-opponent .touch-controls {
+  justify-content: flex-start;
 }
 
 .menu-overlay {
@@ -322,6 +392,7 @@ body.is-touch .weapon-bar {
   align-items: center;
   justify-content: center;
   padding: 24px;
+  overflow-y: auto;
 }
 
 .menu-overlay.hidden {
@@ -338,12 +409,44 @@ body.is-touch .weapon-bar {
   flex-direction: column;
   gap: 18px;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  max-height: min(620px, 92vh);
+  overflow-y: auto;
+}
+
+.menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .menu-panel h1 {
   margin: 0;
   font-size: 24px;
   letter-spacing: 0.6px;
+}
+
+.menu-close-btn {
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 26px;
+  line-height: 1;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.menu-close-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.menu-close-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .menu-tagline {
@@ -377,10 +480,20 @@ body.is-touch .weapon-bar {
   border-radius: 12px;
 }
 
+.menu-option--inline {
+  align-items: center;
+}
+
 .menu-option input[type="radio"],
 .menu-option input[type="checkbox"] {
   margin-top: 2px;
   accent-color: var(--accent);
+}
+
+.menu-helper {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .menu-hints ul {
@@ -395,6 +508,8 @@ body.is-touch .weapon-bar {
 .menu-actions {
   display: flex;
   justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .menu-actions button {
@@ -419,10 +534,30 @@ body.is-touch .weapon-bar {
   transform: translateY(1px);
 }
 
+.menu-secondary-btn {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--fg);
+  border: 1px solid #2b323a;
+}
+
+#menuRestartBtn {
+  display: none;
+}
+
+.menu-secondary-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.menu-secondary-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 @media (max-width: 540px) {
   .menu-panel {
     gap: 16px;
     padding: 22px 20px;
+    width: min(520px, 96vw);
   }
 
   .menu-option {
@@ -431,5 +566,20 @@ body.is-touch .weapon-bar {
 
   .menu-actions button {
     width: 100%;
+  }
+
+  .hud-menu-btn {
+    border-radius: 12px;
+    padding: 8px 10px;
+  }
+
+  .hud-menu-btn__label {
+    display: none;
+  }
+}
+
+@media (min-width: 821px) {
+  .hud-menu-btn {
+    font-size: 13px;
   }
 }

--- a/catiero.html
+++ b/catiero.html
@@ -8,20 +8,30 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="hud">
-      <div class="score">P1 Paw Points: <span id="p1Score">0</span> &nbsp;|&nbsp; P2 Paw Points: <span id="p2Score">0</span></div>
-      <div class="legend">
-        <span class="pill"><span class="p1dot"></span>P1: A/D move · W jump · F boop</span>
-        &nbsp;
-        <span class="pill"><span class="p2dot"></span>P2: ◀︎/▶︎ move · ▲ jump · L boop</span>
-        &nbsp;
-        <span class="pill">P pause · R reset</span>
-        &nbsp;
-        <span class="pill">Weapons — P1 1/2/3 · P2 7/8/9</span>
+    <header class="hud">
+      <button
+        type="button"
+        id="menuToggleBtn"
+        class="hud-menu-btn"
+        aria-haspopup="dialog"
+        aria-controls="menuOverlay"
+        aria-expanded="true"
+      >
+        <span class="hud-menu-btn__icon" aria-hidden="true">☰</span>
+        <span class="hud-menu-btn__label">Menu</span>
+      </button>
+      <div class="scoreboard" aria-live="polite">
+        <div class="scoreboard__item scoreboard__item--p1">
+          <span class="scoreboard__label" id="p1Label">Player 1</span>
+          <span class="scoreboard__score" id="p1Score">0</span>
+        </div>
+        <div class="scoreboard__item scoreboard__item--p2">
+          <span class="scoreboard__label" id="p2Label">Player 2</span>
+          <span class="scoreboard__score" id="p2Score">0</span>
+        </div>
       </div>
-    </div>
+    </header>
     <canvas id="game" width="960" height="540"></canvas>
-    <div class="legend">Catiero v0.1 — Pick <b>Paw Boop</b>, <b>Sausage Bazooka</b>, or <b>Tuna Can Bomb</b>. Use your weapon to reduce rival's <b>Mood</b>; at 0 they <b>respawn</b> and you score a <b>Paw Point</b>. First to 5 wins.</div>
     <div class="weapon-bar" role="region" aria-label="Weapon selection">
       <div class="weapon-panel weapon-panel--p1">
         <div class="weapon-panel__title">Player 1 Weapon (1/2/3)</div>
@@ -74,8 +84,11 @@
 
   <div id="menuOverlay" class="menu-overlay" role="dialog" aria-modal="true" aria-labelledby="menuTitle">
     <div class="menu-panel">
-      <h1 id="menuTitle">Catiero Arena</h1>
-      <p class="menu-tagline">Choose who you’re booping before the match begins.</p>
+      <div class="menu-header">
+        <h1 id="menuTitle">Catiero Arena</h1>
+        <button type="button" id="menuCloseBtn" class="menu-close-btn" aria-label="Close menu">×</button>
+      </div>
+      <p class="menu-tagline">Queue up your cats, weapons, and vibes before the match.</p>
 
       <section class="menu-section" aria-labelledby="modeHeading">
         <h2 id="modeHeading">Game Mode</h2>
@@ -105,6 +118,31 @@
         </label>
       </section>
 
+      <section class="menu-section" aria-labelledby="soundHeading">
+        <h2 id="soundHeading">Sound</h2>
+        <label class="menu-option menu-option--inline">
+          <input type="checkbox" id="soundToggle" checked />
+          Enable crunchy arcade sound effects
+        </label>
+      </section>
+
+      <section class="menu-section" id="weaponRulesSection" aria-labelledby="weaponHeading">
+        <h2 id="weaponHeading">Active Weapons</h2>
+        <p class="menu-helper">Only checked weapons will appear in this match.</p>
+        <label class="menu-option menu-option--inline">
+          <input type="checkbox" name="cat-weapon" value="paw" checked disabled />
+          Paw Boop — the classic close range slap (always enabled)
+        </label>
+        <label class="menu-option menu-option--inline">
+          <input type="checkbox" name="cat-weapon" value="sausage" checked />
+          Sausage Bazooka — mid range launcher
+        </label>
+        <label class="menu-option menu-option--inline">
+          <input type="checkbox" name="cat-weapon" value="tuna" checked />
+          Tuna Can Bomb — bouncy area denial
+        </label>
+      </section>
+
       <section class="menu-section menu-hints" aria-labelledby="controlsHeading">
         <h2 id="controlsHeading">Controls</h2>
         <ul>
@@ -116,7 +154,8 @@
       </section>
 
       <div class="menu-actions">
-        <button id="menuStartBtn">Start Match</button>
+        <button id="menuPrimaryBtn">Start Match</button>
+        <button id="menuRestartBtn" class="menu-secondary-btn" type="button">Restart Match</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the in-game HUD instructions with a responsive pause/menu toggle and scoreboard
- expand the Catiero menu to handle sound toggles, weapon availability, restart/continue flows, and mobile UI tweaks
- add lightweight audio cues, improved AI/touch behaviour, and bouncing tuna bombs with updated projectile logic

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_69093b6170388323814f959397650657