### PR TITLE
Add Calma breathing timer experience

### DIFF
--- a/pure-zen/app.js
+++ b/pure-zen/app.js
@@ -1,0 +1,720 @@
+const SELECTORS = {
+  app: '.app',
+  startBtn: '.start-btn',
+  summaryLength: '[data-summary="length"]',
+  summaryTechnique: '[data-summary="technique"]',
+  chips: '.chip',
+  sheetTrigger: '[data-sheet] ',
+  sheets: '.sheet',
+  sheetBackdrop: '.sheet__backdrop',
+  sliderValue: '[data-slider-value]',
+  slider: '[data-length-slider]',
+  techniqueRadios: 'input[name="technique"]',
+  toggles: '[data-setting]',
+  screenSections: '.screen',
+  time: '[data-time]',
+  phase: '[data-phase]',
+  live: '[data-live]',
+  progress: '.progress-ring__progress',
+  breathCircle: '.breath-circle',
+  pauseBtn: '[data-action="pause"]',
+  endBtn: '[data-action="end"]',
+  soundBtn: '[data-action="sound"]',
+  streak: '[data-streak]'
+};
+
+const TECHNIQUES = {
+  coherent: [
+    { phase: 'inhale', seconds: 5 },
+    { phase: 'exhale', seconds: 5 }
+  ],
+  box: [
+    { phase: 'inhale', seconds: 4 },
+    { phase: 'hold', seconds: 4 },
+    { phase: 'exhale', seconds: 4 },
+    { phase: 'hold', seconds: 4 }
+  ],
+  '478': [
+    { phase: 'inhale', seconds: 4 },
+    { phase: 'hold', seconds: 7 },
+    { phase: 'exhale', seconds: 8 }
+  ]
+};
+
+const DEFAULT_SETTINGS = {
+  lengthMinutes: 5,
+  technique: 'coherent',
+  sound: false,
+  haptics: true,
+  lang: 'en'
+};
+
+const STORAGE_KEYS = {
+  settings: 'pz.settings',
+  streak: 'pz.streak'
+};
+
+const TRANSLATIONS = {
+  en: {
+    tagline: 'Calm breathing. No hurry, no pause.',
+    startLabel: 'Start {minutes}-minute session',
+    changeLength: 'Change length',
+    technique: 'Technique',
+    length: 'Length',
+    pause: 'Pause',
+    resume: 'Resume',
+    end: 'End',
+    done: 'Done. Nice work.',
+    restart: 'Restart',
+    home: 'Home',
+    sound: 'Sound',
+    haptics: 'Haptics',
+    language: 'Language',
+    doneButton: 'Done',
+    coherentInfo: 'Inhale 5s · Exhale 5s',
+    boxInfo: 'Inhale 4s · Hold 4s · Exhale 4s · Hold 4s',
+    '478Info': 'Inhale 4s · Hold 7s · Exhale 8s',
+    inhale: 'Inhale',
+    hold: 'Hold',
+    exhale: 'Exhale',
+    phaseAnnouncement: {
+      inhale: 'Inhale for {seconds} seconds…',
+      hold: 'Hold for {seconds} seconds…',
+      exhale: 'Exhale for {seconds} seconds…'
+    },
+    streak: (current, best) => `Current streak: ${current} days${best ? ` (best ${best})` : ''}`
+  },
+  it: {
+    tagline: 'Respira con calma. Senza fretta, senza pausa.',
+    startLabel: 'Avvia sessione da {minutes} minuti',
+    changeLength: 'Cambia durata',
+    technique: 'Tecnica',
+    length: 'Durata',
+    pause: 'Pausa',
+    resume: 'Riprendi',
+    end: 'Fine',
+    done: 'Fatto. Ottimo.',
+    restart: 'Ricomincia',
+    home: 'Home',
+    sound: 'Suono',
+    haptics: 'Feedback',
+    language: 'Lingua',
+    doneButton: 'Fatto',
+    coherentInfo: 'Inspira 5s · Espira 5s',
+    boxInfo: 'Inspira 4s · Pausa 4s · Espira 4s · Pausa 4s',
+    '478Info': 'Inspira 4s · Pausa 7s · Espira 8s',
+    inhale: 'Inspira',
+    hold: 'Pausa',
+    exhale: 'Espira',
+    phaseAnnouncement: {
+      inhale: 'Inspira per {seconds} secondi…',
+      hold: 'Pausa per {seconds} secondi…',
+      exhale: 'Espira per {seconds} secondi…'
+    },
+    streak: (current, best) => `Serie attuale: ${current} giorni${best ? ` (record ${best})` : ''}`
+  },
+  ru: {
+    tagline: 'Спокойное дыхание. Без спешки, без пауз.',
+    startLabel: 'Старт, {minutes} мин',
+    changeLength: 'Изменить длительность',
+    technique: 'Техника',
+    length: 'Длительность',
+    pause: 'Пауза',
+    resume: 'Продолжить',
+    end: 'Завершить',
+    done: 'Готово. Отлично.',
+    restart: 'Снова',
+    home: 'Домой',
+    sound: 'Звук',
+    haptics: 'Вибрация',
+    language: 'Язык',
+    doneButton: 'Готово',
+    coherentInfo: 'Вдох 5с · Выдох 5с',
+    boxInfo: 'Вдох 4с · Пауза 4с · Выдох 4с · Пауза 4с',
+    '478Info': 'Вдох 4с · Пауза 7с · Выдох 8с',
+    inhale: 'Вдох',
+    hold: 'Задержка',
+    exhale: 'Выдох',
+    phaseAnnouncement: {
+      inhale: 'Вдох на {seconds} секунд…',
+      hold: 'Задержка на {seconds} секунд…',
+      exhale: 'Выдох на {seconds} секунд…'
+    },
+    streak: (current, best) => `Серия: ${current} дн.${best ? ` (лучшее ${best})` : ''}`
+  }
+};
+
+const TECH_LABELS = {
+  coherent: 'Coherent (5-5)',
+  box: 'Box (4-4-4-4)',
+  '478': '4-7-8'
+};
+
+const CIRCUMFERENCE = 2 * Math.PI * 54;
+
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+let audioContext;
+
+function loadSettings() {
+  const stored = localStorage.getItem(STORAGE_KEYS.settings);
+  if (!stored) return { ...DEFAULT_SETTINGS };
+  try {
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) };
+  } catch (error) {
+    console.warn('Failed to parse settings', error);
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+function saveSettings(settings) {
+  localStorage.setItem(STORAGE_KEYS.settings, JSON.stringify(settings));
+}
+
+function loadStreak() {
+  const stored = localStorage.getItem(STORAGE_KEYS.streak);
+  if (!stored) {
+    return {
+      lastCompletionISO: null,
+      currentStreakDays: 0,
+      bestStreakDays: 0
+    };
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return {
+      lastCompletionISO: parsed.lastCompletionISO ?? null,
+      currentStreakDays: parsed.currentStreakDays ?? 0,
+      bestStreakDays: parsed.bestStreakDays ?? 0
+    };
+  } catch (error) {
+    console.warn('Failed to parse streak', error);
+    return {
+      lastCompletionISO: null,
+      currentStreakDays: 0,
+      bestStreakDays: 0
+    };
+  }
+}
+
+function saveStreak(streak) {
+  localStorage.setItem(STORAGE_KEYS.streak, JSON.stringify(streak));
+}
+
+function formatTime(seconds) {
+  const mins = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${mins}:${secs}`;
+}
+
+function buildPhaseTimeline(totalSeconds, steps) {
+  const timeline = [];
+  let remaining = totalSeconds;
+  let i = 0;
+  while (remaining > 0) {
+    const step = steps[i % steps.length];
+    const duration = Math.min(step.seconds, remaining);
+    timeline.push({ phase: step.phase, duration });
+    remaining -= duration;
+    i += 1;
+  }
+  return timeline;
+}
+
+function createAnnouncement(lang, phase, seconds) {
+  const dictionary = TRANSLATIONS[lang].phaseAnnouncement;
+  const template = dictionary[phase] || '';
+  return template.replace('{seconds}', seconds);
+}
+
+function handleHaptics(settings) {
+  if (!settings.haptics) return;
+  if ('vibrate' in navigator) {
+    navigator.vibrate(10);
+  }
+}
+
+async function playBell(settings) {
+  if (!settings.sound) return;
+  try {
+    if (!audioContext) {
+      audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    if (audioContext.state === 'suspended') {
+      await audioContext.resume();
+    }
+    const duration = 0.5;
+    const now = audioContext.currentTime;
+    const oscillator = audioContext.createOscillator();
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(660, now);
+
+    const gain = audioContext.createGain();
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.2, now + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+    oscillator.connect(gain);
+    gain.connect(audioContext.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + duration);
+  } catch (error) {
+    console.warn('Sound playback failed', error);
+  }
+}
+
+class CalmaApp {
+  constructor() {
+    this.settings = loadSettings();
+    this.streak = loadStreak();
+    this.elements = this.getElements();
+    this.session = null;
+    this.isPaused = false;
+    this.lastTick = null;
+    this.remainingSeconds = 0;
+    this.totalSeconds = 0;
+    this.timeline = [];
+    this.timelineIndex = 0;
+    this.timelineElapsed = 0;
+
+    if (this.elements.progress) {
+      this.elements.progress.style.strokeDasharray = CIRCUMFERENCE;
+      this.elements.progress.style.strokeDashoffset = CIRCUMFERENCE;
+    }
+
+    this.bindEvents();
+    this.applyLanguage();
+    this.updateUI();
+    this.applyMotionPreference(prefersReducedMotion.matches);
+
+    prefersReducedMotion.addEventListener('change', (event) => {
+      this.applyMotionPreference(event.matches);
+    });
+  }
+
+  getElements() {
+    const scope = document;
+    return {
+      app: scope.querySelector(SELECTORS.app),
+      startBtn: scope.querySelector(SELECTORS.startBtn),
+      summaryLength: scope.querySelector(SELECTORS.summaryLength),
+      summaryTechnique: scope.querySelector(SELECTORS.summaryTechnique),
+      chips: Array.from(scope.querySelectorAll(SELECTORS.chips)),
+      sliderValue: scope.querySelector(SELECTORS.sliderValue),
+      slider: scope.querySelector(SELECTORS.slider),
+      techniqueRadios: Array.from(scope.querySelectorAll(SELECTORS.techniqueRadios)),
+      toggleInputs: Array.from(scope.querySelectorAll(SELECTORS.toggles)),
+      liveRegion: scope.querySelector(SELECTORS.live),
+      time: scope.querySelector(SELECTORS.time),
+      phase: scope.querySelector(SELECTORS.phase),
+      progress: scope.querySelector(SELECTORS.progress),
+      breathCircle: scope.querySelector(SELECTORS.breathCircle),
+      pauseBtn: scope.querySelector(SELECTORS.pauseBtn),
+      endBtn: scope.querySelector(SELECTORS.endBtn),
+      soundBtn: scope.querySelector(SELECTORS.soundBtn),
+      sheets: Array.from(scope.querySelectorAll(SELECTORS.sheets)),
+      sheetBackdrop: scope.querySelector(SELECTORS.sheetBackdrop),
+      streak: scope.querySelector(SELECTORS.streak)
+    };
+  }
+
+  bindEvents() {
+    this.elements.startBtn.addEventListener('click', () => this.startSession());
+
+    document.addEventListener('click', (event) => {
+      const sheetTrigger = event.target.closest('[data-sheet]');
+      if (sheetTrigger) {
+        const id = sheetTrigger.getAttribute('data-sheet');
+        this.openSheet(id);
+      }
+
+      const closeAction = event.target.closest('[data-action="close-sheet"]');
+      if (closeAction) {
+        this.closeSheets();
+      }
+
+      const chip = event.target.closest('.chip');
+      if (chip) {
+        const minutes = Number(chip.getAttribute('data-length'));
+        if (!Number.isNaN(minutes)) {
+          this.updateSettings({ lengthMinutes: minutes });
+        }
+      }
+
+      const homeAction = event.target.closest('[data-action="home"]');
+      if (homeAction) {
+        this.stopSession();
+        this.showScreen('home');
+      }
+
+      const restartAction = event.target.closest('[data-action="restart"]');
+      if (restartAction) {
+        this.startSession();
+      }
+
+      const soundToggle = event.target.closest('[data-action="sound"]');
+      if (soundToggle) {
+        const pressed = soundToggle.getAttribute('aria-pressed') === 'true';
+        this.updateSettings({ sound: !pressed });
+      }
+    });
+
+    this.elements.sheetBackdrop.addEventListener('click', () => this.closeSheets());
+
+    this.elements.slider.addEventListener('input', (event) => {
+      const minutes = Number(event.target.value);
+      this.elements.sliderValue.textContent = minutes;
+    });
+
+    this.elements.slider.addEventListener('change', (event) => {
+      const minutes = Number(event.target.value);
+      this.updateSettings({ lengthMinutes: minutes });
+    });
+
+    this.elements.techniqueRadios.forEach((radio) => {
+      radio.addEventListener('change', (event) => {
+        if (event.target.checked) {
+          this.updateSettings({ technique: event.target.value });
+        }
+      });
+    });
+
+    this.elements.toggleInputs.forEach((input) => {
+      const setting = input.getAttribute('data-setting');
+      if (!setting) return;
+      input.addEventListener('change', (event) => {
+        const value = input.type === 'checkbox' ? event.target.checked : event.target.value;
+        this.updateSettings({ [setting]: value });
+      });
+    });
+
+    this.elements.pauseBtn.addEventListener('click', () => {
+      if (!this.session) return;
+      if (this.isPaused) {
+        this.resumeSession();
+      } else {
+        this.pauseSession();
+      }
+    });
+
+    this.elements.endBtn.addEventListener('click', () => {
+      this.completeSession(false);
+    });
+  }
+
+  applyLanguage() {
+    const { lang } = this.settings;
+    const dict = TRANSLATIONS[lang];
+    document.documentElement.lang = lang;
+
+    document.querySelectorAll('[data-i18n]').forEach((node) => {
+      const key = node.getAttribute('data-i18n');
+      if (dict[key]) {
+        node.textContent = dict[key];
+      }
+    });
+
+    document.querySelectorAll('[data-i18n-text]').forEach((node) => {
+      const key = node.getAttribute('data-i18n-text');
+      if (dict[key]) {
+        node.textContent = dict[key].replace('{minutes}', this.settings.lengthMinutes);
+      }
+    });
+
+    document.querySelectorAll('[data-i18n-placeholder]').forEach((node) => {
+      const key = node.getAttribute('data-i18n-placeholder');
+      if (dict[key]) {
+        node.setAttribute('placeholder', dict[key]);
+      }
+    });
+
+    this.elements.techniqueRadios.forEach((radio) => {
+      const labelInfo = radio.nextElementSibling?.querySelector('small');
+      if (!labelInfo) return;
+      const infoKey = `${radio.value}Info`;
+      if (dict[infoKey]) {
+        labelInfo.textContent = dict[infoKey];
+      }
+    });
+
+    this.updateStartButton();
+    this.updatePhaseLabel();
+    this.updateStreakMessage();
+    this.setPauseButtonLabel();
+    this.elements.sliderValue.textContent = this.settings.lengthMinutes;
+    this.elements.toggleInputs.forEach((input) => {
+      if (input.getAttribute('data-setting') === 'lang') {
+        input.value = lang;
+      }
+    });
+  }
+
+  applyMotionPreference(isReduced) {
+    if (isReduced) {
+      this.elements.breathCircle.style.transform = 'scale(1)';
+      this.elements.breathCircle.style.transition = 'none';
+    } else {
+      this.elements.breathCircle.style.transition = '';
+    }
+  }
+
+  updateUI() {
+    this.updateChips();
+    this.updateSummary();
+    this.updateStartButton();
+    this.updateSheetControls();
+    this.updateSoundButton();
+    this.updateStreakMessage();
+    this.setPauseButtonLabel();
+  }
+
+  updateChips() {
+    document.querySelectorAll('.chip').forEach((chip) => {
+      const value = Number(chip.getAttribute('data-length'));
+      chip.classList.toggle('is-active', value === this.settings.lengthMinutes);
+    });
+  }
+
+  updateSummary() {
+    this.elements.summaryLength.textContent = `${this.settings.lengthMinutes} min`;
+    this.elements.summaryTechnique.textContent = TECH_LABELS[this.settings.technique];
+  }
+
+  updateStartButton() {
+    const dict = TRANSLATIONS[this.settings.lang];
+    const label = dict.startLabel || TRANSLATIONS.en.startLabel;
+    this.elements.startBtn.textContent = label.replace('{minutes}', this.settings.lengthMinutes);
+  }
+
+  updateSheetControls() {
+    this.elements.slider.value = this.settings.lengthMinutes;
+    this.elements.sliderValue.textContent = this.settings.lengthMinutes;
+
+    this.elements.techniqueRadios.forEach((radio) => {
+      radio.checked = radio.value === this.settings.technique;
+    });
+
+    this.elements.toggleInputs.forEach((input) => {
+      const setting = input.getAttribute('data-setting');
+      if (setting === 'lang') {
+        input.value = this.settings.lang;
+      } else if (input.type === 'checkbox') {
+        input.checked = Boolean(this.settings[setting]);
+      }
+    });
+  }
+
+  updateSoundButton() {
+    this.elements.soundBtn.setAttribute('aria-pressed', this.settings.sound ? 'true' : 'false');
+  }
+
+  openSheet(id) {
+    const sheet = this.elements.sheets.find((el) => el.getAttribute('data-sheet-id') === id);
+    if (!sheet) return;
+    sheet.classList.add('is-active');
+    this.elements.sheetBackdrop.classList.add('is-active');
+    this.elements.sheetBackdrop.hidden = false;
+  }
+
+  closeSheets() {
+    this.elements.sheets.forEach((sheet) => sheet.classList.remove('is-active'));
+    this.elements.sheetBackdrop.classList.remove('is-active');
+    this.elements.sheetBackdrop.hidden = true;
+  }
+
+  updateSettings(partial) {
+    this.settings = { ...this.settings, ...partial };
+    saveSettings(this.settings);
+    this.applyLanguage();
+    this.updateUI();
+  }
+
+  showScreen(id) {
+    this.elements.app.setAttribute('data-screen', id);
+  }
+
+  startSession() {
+    this.closeSheets();
+    this.showScreen('session');
+    this.isPaused = false;
+    this.totalSeconds = this.settings.lengthMinutes * 60;
+    this.remainingSeconds = this.totalSeconds;
+    this.timeline = buildPhaseTimeline(this.totalSeconds, TECHNIQUES[this.settings.technique]);
+    this.timelineIndex = 0;
+    this.timelineElapsed = 0;
+    this.lastTick = null;
+    this.session = true;
+    this.setPauseButtonLabel();
+    this.elements.time.textContent = formatTime(this.remainingSeconds);
+    this.updatePhaseLabel();
+    this.updateProgress();
+    this.schedulePhaseCue();
+    this.updateBreathCircle('start');
+    playBell(this.settings);
+
+    cancelAnimationFrame(this.rafId);
+    this.rafId = requestAnimationFrame((timestamp) => this.tick(timestamp));
+  }
+
+  pauseSession() {
+    this.isPaused = true;
+    this.setPauseButtonLabel();
+  }
+
+  resumeSession() {
+    this.isPaused = false;
+    this.setPauseButtonLabel();
+    this.lastTick = null;
+    this.rafId = requestAnimationFrame((timestamp) => this.tick(timestamp));
+  }
+
+  stopSession() {
+    cancelAnimationFrame(this.rafId);
+    this.session = null;
+  }
+
+  updateProgress() {
+    const offset = CIRCUMFERENCE * (this.remainingSeconds / this.totalSeconds);
+    this.elements.progress.style.strokeDashoffset = offset;
+    this.elements.time.textContent = formatTime(this.remainingSeconds);
+  }
+
+  updatePhaseLabel() {
+    if (!this.timeline.length) {
+      this.elements.phase.textContent = TRANSLATIONS[this.settings.lang].inhale;
+      return;
+    }
+    const current = this.timeline[this.timelineIndex] || this.timeline[this.timeline.length - 1];
+    this.elements.phase.textContent = TRANSLATIONS[this.settings.lang][current.phase];
+  }
+
+  schedulePhaseCue() {
+    const current = this.timeline[this.timelineIndex];
+    if (!current) return;
+    const message = createAnnouncement(this.settings.lang, current.phase, current.duration);
+    if (message) {
+      this.elements.liveRegion.textContent = message;
+    }
+    handleHaptics(this.settings);
+    this.updatePhaseLabel();
+    this.updateBreathCircle(current.phase, current.duration);
+  }
+
+  updateBreathCircle(phase, duration = 0) {
+    if (prefersReducedMotion.matches) return;
+    const circle = this.elements.breathCircle;
+    if (phase === 'inhale' || phase === 'start') {
+      circle.style.transitionDuration = `${duration || 3}s`;
+      circle.style.transform = 'scale(1.08)';
+    } else if (phase === 'hold') {
+      circle.style.transitionDuration = '0.2s';
+      circle.style.transform = 'scale(1.08)';
+    } else if (phase === 'exhale') {
+      circle.style.transitionDuration = `${duration || 3}s`;
+      circle.style.transform = 'scale(0.9)';
+    }
+  }
+
+  tick(timestamp) {
+    if (!this.session) return;
+    if (this.isPaused) {
+      this.rafId = requestAnimationFrame((t) => this.tick(t));
+      return;
+    }
+
+    if (!this.lastTick) {
+      this.lastTick = timestamp;
+    }
+
+    let delta = (timestamp - this.lastTick) / 1000;
+    this.lastTick = timestamp;
+
+    this.remainingSeconds = Math.max(this.remainingSeconds - delta, 0);
+
+    while (delta > 0 && this.timelineIndex < this.timeline.length) {
+      const currentSegment = this.timeline[this.timelineIndex];
+      const remainingInSegment = currentSegment.duration - this.timelineElapsed;
+
+      if (delta + 0.0001 >= remainingInSegment) {
+        delta -= remainingInSegment;
+        this.timelineIndex += 1;
+        this.timelineElapsed = 0;
+        this.schedulePhaseCue();
+      } else {
+        this.timelineElapsed += delta;
+        delta = 0;
+      }
+    }
+
+    if (this.remainingSeconds <= 0.01) {
+      this.completeSession(true);
+      return;
+    }
+
+    this.updateProgress();
+    this.rafId = requestAnimationFrame((t) => this.tick(t));
+  }
+
+  completeSession(success) {
+    if (!this.session) return;
+    this.stopSession();
+    this.showScreen('complete');
+    cancelAnimationFrame(this.rafId);
+
+    if (success) {
+      if (this.totalSeconds >= 120) {
+        this.updateStreak();
+      }
+      playBell(this.settings);
+    }
+
+    this.updateStreakMessage();
+  }
+
+  updateStreak() {
+    const now = new Date();
+    const todayKey = now.toISOString().slice(0, 10);
+    const last = this.streak.lastCompletionISO ? this.streak.lastCompletionISO.slice(0, 10) : null;
+
+    if (last === todayKey) {
+      return;
+    }
+
+    if (last) {
+      const lastDate = new Date(last);
+      const diff = Math.floor((now - lastDate) / (1000 * 60 * 60 * 24));
+      if (diff === 1) {
+        this.streak.currentStreakDays += 1;
+      } else {
+        this.streak.currentStreakDays = 1;
+      }
+    } else {
+      this.streak.currentStreakDays = 1;
+    }
+
+    this.streak.bestStreakDays = Math.max(this.streak.bestStreakDays, this.streak.currentStreakDays);
+    this.streak.lastCompletionISO = now.toISOString();
+    saveStreak(this.streak);
+  }
+
+  updateStreakMessage() {
+    const dict = TRANSLATIONS[this.settings.lang];
+    const message = dict.streak(this.streak.currentStreakDays ?? 0, this.streak.bestStreakDays ?? 0);
+    this.elements.streak.textContent = message;
+  }
+
+  setPauseButtonLabel() {
+    const dict = TRANSLATIONS[this.settings.lang];
+    const key = this.isPaused ? 'resume' : 'pause';
+    this.elements.pauseBtn.textContent = dict[key];
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  new CalmaApp();
+});

--- a/pure-zen/assets/icon.svg
+++ b/pure-zen/assets/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <radialGradient id="a" cx="50%" cy="30%" r="75%">
+      <stop offset="0%" stop-color="#4c7cf3" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#4c7cf3" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="120" height="120" rx="28" ry="28" fill="#f7f7f7" />
+  <circle cx="60" cy="60" r="40" fill="url(#a)" />
+  <circle cx="60" cy="60" r="26" fill="#4c7cf3" opacity="0.9" />
+</svg>

--- a/pure-zen/index.html
+++ b/pure-zen/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calma</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app" data-screen="home">
+    <header class="hero">
+      <h1 class="logo">Calma</h1>
+      <p class="tagline" data-i18n="tagline">Calm breathing. No hurry, no pause.</p>
+    </header>
+
+    <main>
+      <section class="screen screen--home" data-screen-id="home">
+        <button class="btn btn--primary start-btn" type="button" data-i18n-text="startLabel">Start 5-minute session</button>
+
+        <div class="chip-row" role="list">
+          <button class="chip" data-length="2" role="listitem">2m</button>
+          <button class="chip" data-length="5" role="listitem">5m</button>
+          <button class="chip" data-length="10" role="listitem">10m</button>
+        </div>
+
+        <div class="link-row">
+          <button class="link" type="button" data-sheet="length" data-i18n="changeLength">Change length</button>
+          <button class="link" type="button" data-sheet="technique" data-i18n="technique">Technique</button>
+        </div>
+
+        <dl class="summary">
+          <div>
+            <dt data-i18n="length">Length</dt>
+            <dd class="summary__value" data-summary="length"></dd>
+          </div>
+          <div>
+            <dt data-i18n="technique">Technique</dt>
+            <dd class="summary__value" data-summary="technique"></dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="screen screen--session" data-screen-id="session" aria-live="polite">
+        <div class="session-visual">
+          <svg class="progress-ring" viewBox="0 0 120 120" aria-hidden="true">
+            <circle class="progress-ring__bg" cx="60" cy="60" r="54"></circle>
+            <circle class="progress-ring__progress" cx="60" cy="60" r="54"></circle>
+          </svg>
+          <div class="breath-circle" aria-hidden="true"></div>
+          <div class="session-readout">
+            <p class="time" data-time>05:00</p>
+            <p class="phase" data-phase>Inhale</p>
+          </div>
+        </div>
+        <div class="controls">
+          <button class="btn btn--primary" type="button" data-action="pause" data-i18n="pause">Pause</button>
+          <button class="btn btn--ghost" type="button" data-action="end" data-i18n="end">End</button>
+          <button class="icon-btn" type="button" data-action="sound" aria-pressed="false" aria-label="Toggle sound">
+            <span class="icon-sound" aria-hidden="true"></span>
+          </button>
+        </div>
+      </section>
+
+      <section class="screen screen--complete" data-screen-id="complete">
+        <h2 data-i18n="done">Done. Nice work.</h2>
+        <p class="streak" data-streak></p>
+        <div class="controls">
+          <button class="btn btn--primary" type="button" data-action="restart" data-i18n="restart">Restart</button>
+          <button class="btn btn--ghost" type="button" data-action="home" data-i18n="home">Home</button>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <div class="sheet" data-sheet-id="length" role="dialog" aria-modal="true" aria-labelledby="length-sheet-title">
+    <div class="sheet__content">
+      <header class="sheet__header">
+        <h2 id="length-sheet-title" data-i18n="length">Length</h2>
+        <button class="icon-btn" type="button" data-action="close-sheet" aria-label="Close"></button>
+      </header>
+      <div class="sheet__body">
+        <div class="chip-row" role="list">
+          <button class="chip" data-length="2" role="listitem">2m</button>
+          <button class="chip" data-length="5" role="listitem">5m</button>
+          <button class="chip" data-length="10" role="listitem">10m</button>
+        </div>
+        <label class="slider-label">
+          <span data-i18n="length"></span>
+          <span class="slider-value" data-slider-value>5</span>
+        </label>
+        <input type="range" min="1" max="20" value="5" class="slider" data-length-slider />
+      </div>
+      <footer class="sheet__footer">
+        <button class="btn btn--primary" type="button" data-action="close-sheet" data-i18n="doneButton">Done</button>
+      </footer>
+    </div>
+  </div>
+
+  <div class="sheet" data-sheet-id="technique" role="dialog" aria-modal="true" aria-labelledby="technique-sheet-title">
+    <div class="sheet__content">
+      <header class="sheet__header">
+        <h2 id="technique-sheet-title" data-i18n="technique">Technique</h2>
+        <button class="icon-btn" type="button" data-action="close-sheet" aria-label="Close"></button>
+      </header>
+      <div class="sheet__body">
+        <fieldset class="radio-list">
+          <legend class="sr-only" data-i18n="technique">Technique</legend>
+          <label class="radio">
+            <input type="radio" name="technique" value="coherent" checked />
+            <span>
+              <strong>Coherent (5-5)</strong>
+              <small data-i18n="coherentInfo">Inhale 5s · Exhale 5s</small>
+            </span>
+          </label>
+          <label class="radio">
+            <input type="radio" name="technique" value="box" />
+            <span>
+              <strong>Box (4-4-4-4)</strong>
+              <small data-i18n="boxInfo">Inhale 4s · Hold 4s · Exhale 4s · Hold 4s</small>
+            </span>
+          </label>
+          <label class="radio">
+            <input type="radio" name="technique" value="478" />
+            <span>
+              <strong>4-7-8</strong>
+              <small data-i18n="478Info">Inhale 4s · Hold 7s · Exhale 8s</small>
+            </span>
+          </label>
+        </fieldset>
+        <div class="toggle-row">
+          <label class="toggle">
+            <input type="checkbox" data-setting="sound" />
+            <span class="toggle__label" data-i18n="sound">Sound</span>
+          </label>
+          <label class="toggle">
+            <input type="checkbox" data-setting="haptics" checked />
+            <span class="toggle__label" data-i18n="haptics">Haptics</span>
+          </label>
+        </div>
+        <label class="select">
+          <span data-i18n="language">Language</span>
+          <select data-setting="lang">
+            <option value="en">English</option>
+            <option value="it">Italiano</option>
+            <option value="ru">Русский</option>
+          </select>
+        </label>
+      </div>
+      <footer class="sheet__footer">
+        <button class="btn btn--primary" type="button" data-action="close-sheet" data-i18n="doneButton">Done</button>
+      </footer>
+    </div>
+  </div>
+
+  <div class="sheet__backdrop" hidden></div>
+
+  <div class="sr-only" aria-live="polite" data-live></div>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/pure-zen/styles.css
+++ b/pure-zen/styles.css
@@ -1,0 +1,397 @@
+:root {
+  --bg: #f7f7f7;
+  --ink: #111;
+  --muted: #666;
+  --accent: #4c7cf3;
+  --ring: #4c7cf3;
+  --radius: 14px;
+  --space: 16px;
+  font-family: 'Inter', 'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+}
+
+.app {
+  width: min(100%, 480px);
+  padding: calc(var(--space) * 2) var(--space) calc(var(--space) * 3);
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: calc(var(--space) * 2);
+}
+
+.logo {
+  font-size: 2.2rem;
+  margin: 0 0 0.25rem;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+}
+
+.screen {
+  display: none;
+}
+
+.app[data-screen="home"] .screen--home,
+.app[data-screen="session"] .screen--session,
+.app[data-screen="complete"] .screen--complete {
+  display: block;
+}
+
+.btn {
+  border: 0;
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(76, 124, 243, 0.25);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(76, 124, 243, 0.3);
+}
+
+.btn:focus-visible,
+.chip:focus-visible,
+.link:focus-visible,
+.icon-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.start-btn {
+  width: 100%;
+  margin-bottom: calc(var(--space) * 1.5);
+  font-size: 1.2rem;
+}
+
+.chip-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: var(--space);
+}
+
+.chip {
+  border: 1px solid rgba(17, 17, 17, 0.1);
+  background: #fff;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  color: var(--muted);
+}
+
+.chip.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(76, 124, 243, 0.1);
+}
+
+.link-row {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: calc(var(--space) * 1.5);
+}
+
+.link {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: 0.95rem;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space);
+  margin: 0;
+  padding: 0;
+}
+
+.summary div {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: var(--space);
+  box-shadow: 0 6px 20px rgba(17, 17, 17, 0.08);
+}
+
+.summary dt {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.summary__value {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.session-visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+  margin-bottom: calc(var(--space) * 2);
+}
+
+.progress-ring {
+  width: clamp(200px, 60vw, 280px);
+  height: auto;
+}
+
+.progress-ring__bg {
+  fill: none;
+  stroke: rgba(17, 17, 17, 0.08);
+  stroke-width: 8;
+}
+
+.progress-ring__progress {
+  fill: none;
+  stroke: var(--ring);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  stroke-dasharray: 339.292;
+  stroke-dashoffset: 339.292;
+  transition: stroke-dashoffset 0.25s linear;
+}
+
+.breath-circle {
+  position: absolute;
+  width: clamp(160px, 50vw, 220px);
+  height: clamp(160px, 50vw, 220px);
+  border-radius: 50%;
+  background: radial-gradient(circle at top, rgba(76, 124, 243, 0.15), rgba(76, 124, 243, 0));
+  transform: scale(0.9);
+  transition: transform 3s ease-in-out;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breath-circle {
+    transition: none;
+  }
+}
+
+.session-readout {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  gap: 4px;
+}
+
+.session-readout .time {
+  font-size: clamp(2.2rem, 6vw, 3rem);
+  margin: 0;
+}
+
+.session-readout .phase {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.icon-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(17, 17, 17, 0.1);
+  background: #fff;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.icon-btn[aria-pressed="true"] {
+  border-color: var(--accent);
+  background: rgba(76, 124, 243, 0.15);
+}
+
+.icon-sound {
+  width: 20px;
+  height: 20px;
+  background: center / contain no-repeat url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="%23111" stroke-width="1.7"%3E%3Cpath stroke-linecap="round" stroke-linejoin="round" d="M9 9l5-4v14l-5-4H5V9h4zm7.5-2.5a5 5 0 010 10m-2-8a3 3 0 010 6"/%3E%3C/svg%3E');
+}
+
+.screen--complete {
+  text-align: center;
+}
+
+.screen--complete h2 {
+  font-size: 1.8rem;
+}
+
+.streak {
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.sheet {
+  position: fixed;
+  inset: auto 0 0;
+  max-width: 480px;
+  margin: 0 auto;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.sheet.is-active {
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.sheet__content {
+  background: #fff;
+  border-radius: var(--radius) var(--radius) 0 0;
+  box-shadow: 0 -10px 30px rgba(17, 17, 17, 0.15);
+  padding: var(--space);
+}
+
+.sheet__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space);
+}
+
+.sheet__body {
+  display: grid;
+  gap: var(--space);
+}
+
+.sheet__footer {
+  margin-top: var(--space);
+}
+
+.slider-label {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.slider {
+  width: 100%;
+}
+
+.radio-list {
+  display: grid;
+  gap: 12px;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.radio {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: rgba(17, 17, 17, 0.04);
+  border-radius: var(--radius);
+  padding: 12px;
+}
+
+.radio input {
+  width: 20px;
+  height: 20px;
+}
+
+.radio small {
+  color: var(--muted);
+}
+
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.select {
+  display: grid;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.sheet__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 17, 17, 0.35);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+  z-index: 90;
+}
+
+.sheet__backdrop.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 600px) {
+  body {
+    padding: 40px 0;
+  }
+
+  .sheet {
+    inset: auto auto 40px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Calma meditation experience under `pure-zen/` with home, session, and completion screens
- implement breathing engine with multilingual cues, haptics, optional sound, and local streak tracking
- style the interface for mobile-first use, including animated progress ring and supportive icon asset

## Testing
- Manual testing

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c3dc77148323be69bc25947fa4ee)